### PR TITLE
add pixel_tracker.py

### DIFF
--- a/terasaki/pixel_tracker.py
+++ b/terasaki/pixel_tracker.py
@@ -52,10 +52,7 @@ def exist_start(domain,coords):
     return False,None
 
 def condi(domain,traced,c,direc):
-    if not np.all(direc==0) and domain[tuple(c+direc)]==1 and traced[tuple(c+direc)]==0:
-        return True
-    else:
-        return False
+    return not np.all(direc==0) and domain[tuple(c+direc)]==1 and traced[tuple(c+direc)]==0
 
 def find_next_coord(dom,tr,c,direc):
     if dom[tuple(direc+c)]==1:

--- a/terasaki/pixel_tracker.py
+++ b/terasaki/pixel_tracker.py
@@ -10,11 +10,11 @@ def generate_square_on_domain(domain_sizes=25):
     upper_left_y=3
     #make square
     for i in range(row_size):
-        domain[upper_left_x+i][upper_left_y]=1
-        domain[upper_left_x+i][upper_left_y+(col_size-1)]=1
+        domain[upper_left_y+i][upper_left_x]=1
+        domain[upper_left_y+i][upper_left_x+(col_size-1)]=1
     for j in range(col_size):
-        domain[upper_left_x,upper_left_y+j]=1
-        domain[upper_left_x+(row_size-1),upper_left_y+j]=1
+        domain[upper_left_y,upper_left_x+j]=1
+        domain[upper_left_y+(row_size-1),upper_left_x+j]=1
     return domain
 
 def generate_Sigma_curve_on_domain(domain_sizes=25):
@@ -27,11 +27,13 @@ def generate_Sigma_curve_on_domain(domain_sizes=25):
 
     #make horizontal
     for j in range(row_length):
-        domain[upper_left_x,upper_left_y+j]=1
-        domain[upper_left_x+row_length,upper_left_y+j]=1
+        domain[upper_left_y,upper_left_x+j]=1
+        domain[upper_left_y+row_length,upper_left_x+j]=1
     for k in range(8):
-        domain[upper_left_x+k][upper_left_y+k]=1
-        domain[upper_left_x+vertical_length-1-k][upper_left_y+k]=1
+        domain[upper_left_y+k][upper_left_x+k]=1
+        domain[upper_left_y+vertical_length-1-k][upper_left_x+k]=1
+    #add accent
+    domain[upper_left_y+1][upper_left_x+row_length-1]=1
     return domain
     
 

--- a/terasaki/pixel_tracker.py
+++ b/terasaki/pixel_tracker.py
@@ -38,11 +38,7 @@ def generate_Sigma_curve_on_domain(domain_sizes=25):
     
 
 def collect_curve_coordinates(domain):
-    coords=[]
-    for ind,val in np.ndenumerate(domain):
-        if val==1:
-            coords.append(ind)
-    return coords
+    return [ind for ind,val in np.ndenumerate(domain) if val==1]
 
 def surro(dom,c,direc):
     return not np.all(direc==0) and domain[tuple(c+direc)]==1

--- a/terasaki/pixel_tracker.py
+++ b/terasaki/pixel_tracker.py
@@ -60,7 +60,6 @@ def exist_start(domain,coords):
             ext_sub_dom=[domain[tuple(c+np.array([i,j]))] for i in [-2,-1,0,1,2] for j in [-2,-1,0,1,2]]
             if np.count_nonzero(ext_sub_dom)==4:
                 candidates=[np.array([i,j]) for i in [-1,0,1] for j in [-1,0,1] if surro(domain,c,np.array([i,j]))]
-                print(candidates)
                 if all([domain[tuple(c+2*candi)]==0 for candi in candidates])==True:
                     return True,c
     return False,None

--- a/terasaki/pixel_tracker.py
+++ b/terasaki/pixel_tracker.py
@@ -44,11 +44,31 @@ def collect_curve_coordinates(domain):
             coords.append(ind)
     return coords
 
+def surro(dom,c,direc):
+    return not np.all(direc==0) and domain[tuple(c+direc)]==1
+
 def exist_start(domain,coords):
     for c in coords:
-        sub_dom=[domain[tuple(c+np.array([i,j]))] for i in [-1,0,1] for j in [-1,0,1]]
+        sub_dom=np.array([domain[tuple(c+np.array([i,j]))] for i in [-1,0,1] for j in [-1,0,1]]).reshape(3,3)
         if np.count_nonzero(sub_dom)==2:
             return True,c
+        elif np.count_nonzero(sub_dom)==3:
+            y_num=[i for i in range(sub_dom.shape[0]) if np.any(sub_dom[i])==1]
+            x_num=[j for j in range(sub_dom.shape[1]) if np.any(sub_dom[:,j])==1]
+            if len(x_num)==3 or len(y_num)==3:
+                continue
+            ext_sub_dom=[domain[tuple(c+np.array([i,j]))] for i in [-2,-1,0,1,2] for j in [-2,-1,0,1,2]]
+            if np.count_nonzero(ext_sub_dom)==4:
+                candidates=[np.array([i,j]) for i in [-1,0,1] for j in [-1,0,1] if surro(domain,c,np.array([i,j]))]
+                print(candidates)
+                if all([domain[tuple(c+2*candi)]==0 for candi in candidates])==True:
+                    return True,c
+                else :
+                    continue
+            else :
+                continue
+        else:
+            continue
     return False,None
 
 def condi(domain,traced,c,direc):

--- a/terasaki/pixel_tracker.py
+++ b/terasaki/pixel_tracker.py
@@ -45,7 +45,8 @@ def surro(dom,c,direc):
 
 def exist_start(domain,coords):
     for c in coords:
-        sub_dom=np.array([domain[tuple(c+np.array([i,j]))] for i in [-1,0,1] for j in [-1,0,1]]).reshape(3,3)
+        sub_dom=np.array([domain[tuple(c+np.array([i,j]))] 
+                            for i in [-1,0,1] for j in [-1,0,1]]).reshape(3,3)
         if np.count_nonzero(sub_dom)==2:
             return True,c
         elif np.count_nonzero(sub_dom)==3:
@@ -53,7 +54,8 @@ def exist_start(domain,coords):
             x_num=[j for j in range(sub_dom.shape[1]) if np.any(sub_dom[:,j])==1]
             if len(x_num)==3 or len(y_num)==3:
                 continue
-            ext_sub_dom=[domain[tuple(c+np.array([i,j]))] for i in [-2,-1,0,1,2] for j in [-2,-1,0,1,2]]
+            ext_sub_dom=[domain[tuple(c+np.array([i,j]))] 
+                            for i in [-2,-1,0,1,2] for j in [-2,-1,0,1,2]]
             if np.count_nonzero(ext_sub_dom)==4:
                 candidates=[np.array([i,j]) for i in [-1,0,1] for j in [-1,0,1] if surro(domain,c,np.array([i,j]))]
                 if all([domain[tuple(c+2*candi)]==0 for candi in candidates])==True:

--- a/terasaki/pixel_tracker.py
+++ b/terasaki/pixel_tracker.py
@@ -1,0 +1,101 @@
+#this program is written by Python its version is 3.5.1
+import numpy as np 
+
+def generate_square_on_domain(domain_sizes=25):
+    domain=np.zeros((domain_sizes,domain_sizes),dtype=int)
+    #define test domain size
+    row_size=14
+    col_size=14
+    upper_left_x=3
+    upper_left_y=3
+    #make square
+    for i in range(row_size):
+        domain[upper_left_x+i][upper_left_y]=1
+        domain[upper_left_x+i][upper_left_y+(col_size-1)]=1
+    for j in range(col_size):
+        domain[upper_left_x,upper_left_y+j]=1
+        domain[upper_left_x+(row_size-1),upper_left_y+j]=1
+    return domain
+
+def generate_Sigma_curve_on_domain(domain_sizes=25):
+    domain=np.zeros((domain_sizes,domain_sizes),dtype=int)
+    #define test domain size
+    row_length=14
+    vertical_length=15
+    upper_left_x=3
+    upper_left_y=3
+
+    #make horizontal
+    for j in range(row_length):
+        domain[upper_left_x,upper_left_y+j]=1
+        domain[upper_left_x+row_length,upper_left_y+j]=1
+    for k in range(8):
+        domain[upper_left_x+k][upper_left_y+k]=1
+        domain[upper_left_x+vertical_length-1-k][upper_left_y+k]=1
+    return domain
+    
+
+def collect_curve_coordinates(domain):
+    coords=[]
+    for ind,val in np.ndenumerate(domain):
+        if val==1:
+            coords.append(ind)
+    return coords
+
+def exist_start(domain,coords):
+    for c in coords:
+        sub_dom=[domain[tuple(c+np.array([i,j]))] for i in [-1,0,1] for j in [-1,0,1]]
+        if np.count_nonzero(sub_dom)==2:
+            return True,c
+    return False,None
+
+def condi(domain,traced,c,direc):
+    if not np.all(direc==0) and domain[tuple(c+direc)]==1 and traced[tuple(c+direc)]==0:
+        return True
+    else:
+        return False
+
+def find_next_coord(dom,tr,c,direc):
+    if dom[tuple(direc+c)]==1:
+        return np.array(c+direc),direc
+    else:
+        candidates=[np.array([i,j]) for i in [-1,0,1] for j in [-1,0,1] if condi(dom,tr,c,np.array([i,j]))]
+        dists=[abs(cand).sum() for cand in candidates]
+        return np.array(candidates[np.argmin(dists)]+c),candidates[np.argmin(dists)]
+
+if __name__ == '__main__':
+    #domain=generate_square_on_domain()
+    domain=generate_Sigma_curve_on_domain()
+    print("create test domain\n",domain)
+    coords=collect_curve_coordinates(domain)
+    is_exist,start_coord=exist_start(domain,coords)
+    if is_exist:
+        print("start coordinate is",start_coord)
+    else:
+        print("this curve is link. We chose start coords from",coords[0])
+        start_coord=coords[0]
+
+    traced_table=np.zeros(domain.shape,dtype=int)
+    traced_table[start_coord[0]][start_coord[1]]=1
+    #set initial value
+    #note that direc stands for direction
+    coord=np.array(start_coord)
+    direc=np.array([0,1])
+
+    while(not np.all(domain==traced_table)):
+        next_coord,next_direc=find_next_coord(domain,traced_table,coord,direc)
+        #for debug
+        print("next=",next_coord)
+        print(next_direc)
+
+        #update for next step
+        coord=next_coord
+        direc=next_direc
+        traced_table[next_coord[0]][next_coord[1]]=1
+        
+        #for debug
+        print(traced_table)
+
+    print("finish !!!")
+    print("track result=\n", traced_table)
+

--- a/terasaki/pixel_tracker.py
+++ b/terasaki/pixel_tracker.py
@@ -63,12 +63,6 @@ def exist_start(domain,coords):
                 print(candidates)
                 if all([domain[tuple(c+2*candi)]==0 for candi in candidates])==True:
                     return True,c
-                else :
-                    continue
-            else :
-                continue
-        else:
-            continue
     return False,None
 
 def condi(domain,traced,c,direc):

--- a/terasaki/pixel_tracker.py
+++ b/terasaki/pixel_tracker.py
@@ -68,8 +68,8 @@ def find_next_coord(dom,tr,c,direc):
         return np.array(c+direc),direc
     else:
         candidates=[np.array([i,j]) for i in [-1,0,1] for j in [-1,0,1] if condi(dom,tr,c,np.array([i,j]))]
-        dists=[abs(cand).sum() for cand in candidates]
-        return np.array(candidates[np.argmin(dists)]+c),candidates[np.argmin(dists)]
+        manhattan_dists=[abs(cand).sum() for cand in candidates]
+        return np.array(candidates[np.argmin(manhattan_dists)]+c),candidates[np.argmin(manhattan_dists)]
 
 if __name__ == '__main__':
     #domain=generate_square_on_domain()

--- a/terasaki/pixel_tracker.py
+++ b/terasaki/pixel_tracker.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
         start_coord=coords[0]
 
     traced_table=np.zeros(domain.shape,dtype=int)
-    traced_table[start_coord[0]][start_coord[1]]=1
+    traced_table[start_coord]=1
     #set initial value
     #note that direc stands for direction
     coord=np.array(start_coord)
@@ -103,7 +103,7 @@ if __name__ == '__main__':
         #update for next step
         coord=next_coord
         direc=next_direc
-        traced_table[next_coord[0]][next_coord[1]]=1
+        traced_table[tuple(next_coord)]=1
         
         #for debug
         print(traced_table)


### PR DESCRIPTION
0，1からなる2値マップ上で曲線を1としてみた時に曲線をトレース（ある地点から出発し，出発点の近傍(現在点から周りの九個の領域を対象で1の値を持つ場所を探しそれを逐次実行）する機能を作りました．

曲線が紐状（端点がある）場合，端点を検出してそこからトレースを始めます．
曲線が閉じた輪になる場合は始点は不定ですが，曲線上のある位置からトレースを始めます．
ただし，制限事項として曲線はマップ上で一本しか許しません．
互いに交わらない二本の線分が存在するとアルゴリズムは終了しない可能性があります．

トレースをする中で
既に見たところ，と前のステップでの曲線の進行方向を記憶しています．
次の1の場所を探す際jに，記憶していた進行方向の1の向きを優先します．
このようにしないといけないのは斜め線から水平方向に行く角でうまく処理が進まないことを防ぐためです，
